### PR TITLE
New Feature: robots.txt

### DIFF
--- a/app/code/community/Loewenstark/Seo/Helper/Data.php
+++ b/app/code/community/Loewenstark/Seo/Helper/Data.php
@@ -27,7 +27,7 @@ extends Mage_Core_Helper_Abstract
      */
     public function getDefaultRobots()
     {
-        return Mage::getStoreConfig(self::XML_PATH_DEFAULT_ROBOTS);;
+        return Mage::getStoreConfig(self::XML_PATH_DEFAULT_ROBOTS);
     }
 
     /**
@@ -76,7 +76,7 @@ extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * 
+     *
      * @return string
      */
     public function isPhraseEnabled()

--- a/app/code/community/Loewenstark/Seo/Helper/Robotstxt.php
+++ b/app/code/community/Loewenstark/Seo/Helper/Robotstxt.php
@@ -1,0 +1,37 @@
+<?php
+/**
+  * Loewenstark_Seo
+  *
+  * @category  Loewenstark
+  * @package   Loewenstark_Seo
+  * @author    Mathis Klooss <m.klooss@loewenstark.com>
+  * @copyright 2013 Loewenstark Web-Solution GmbH (http://www.mage-profis.de/). All rights served.
+  * @license   https://github.com/mklooss/Loewenstark_Seo/blob/master/README.md
+  */
+class Loewenstark_Seo_Helper_Robotstxt extends Mage_Core_Helper_Abstract
+{
+    const XML_PATH_LOEWENSTARK_SEO_ROBOTSTXT = 'catalog/seo/robotstxt';
+
+    /**
+     * Get content type for robots.txt
+     *
+     * @return string
+     */
+    public function getContentType()
+    {
+        return "text/plain; charset=UTF-8";
+    }
+
+    /**
+     *
+     * Get content for robots.txt file
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        $content = Mage::getStoreConfig(self::XML_PATH_LOEWENSTARK_SEO_ROBOTSTXT);
+        $processor = Mage::getModel('cms/template_filter');
+        return $processor->filter($content);
+    }
+}

--- a/app/code/community/Loewenstark/Seo/Model/Observer.php
+++ b/app/code/community/Loewenstark/Seo/Model/Observer.php
@@ -381,7 +381,7 @@ class Loewenstark_Seo_Model_Observer
     {
         $params['_nosid'] = true;
         $url = Mage::getUrl($url, $params);
-        return $this->parseUrl($url);;
+        return $this->parseUrl($url);
     }
 
     /**

--- a/app/code/community/Loewenstark/Seo/controller/RobotstxtController.php
+++ b/app/code/community/Loewenstark/Seo/controller/RobotstxtController.php
@@ -1,0 +1,30 @@
+<?php
+class Loewenstark_Seo_RobotstxtController extends Mage_Core_Controller_Front_Action
+{
+    private $_helper;
+
+    /**
+     * Render robots.txt
+     *
+     * This action pulls the relevant system config data and simply
+     * echoes it to the browser.
+     */
+    public function indexAction()
+    {
+        Mage::app()->getResponse()->setHeader("Content-Type", $this->_helper()->getContentType(), true);
+        echo $this->_helper()->getContent();
+    }
+
+    /**
+     * Load helper
+     *
+     * @return Mage_Core_Helper_Abstract
+     */
+    protected function _helper($helper = 'loewenstark_seo/robotstxt')
+    {
+        if (is_null($this->_helper[$helper])) {
+            $this->_helper[$helper] = Mage::helper($helper);
+        }
+        return $this->_helper[$helper];
+    }
+}

--- a/app/code/community/Loewenstark/Seo/controllers/IndexController.php
+++ b/app/code/community/Loewenstark/Seo/controllers/IndexController.php
@@ -1,5 +1,12 @@
 <?php
-class Loewenstark_Seo_RobotstxtController extends Mage_Core_Controller_Front_Action
+/**
+ * This is the controller for rendering the robots.txt file.
+ *
+ * @category  Loewenstark
+ * @package   Loewenstark_Seo
+ * @author    Volker Thiel <volker@mage-profis.de>
+ */
+class Loewenstark_Seo_IndexController extends Mage_Core_Controller_Front_Action
 {
     private $_helper;
 

--- a/app/code/community/Loewenstark/Seo/etc/config.xml
+++ b/app/code/community/Loewenstark/Seo/etc/config.xml
@@ -13,10 +13,19 @@
 <config>
     <modules>
         <Loewenstark_Seo>
-            <version>1.0.0.1</version>
+            <version>1.0.1.0</version>
         </Loewenstark_Seo>
     </modules>
     <frontend>
+        <routers>
+            <Loewenstark_Seo_RobotsTxt>
+                <use>standard</use>
+                <args>
+                    <module>Loewenstark_Seo</module>
+                    <frontName>robots.txt</frontName>
+                </args>
+            </Loewenstark_Seo_RobotsTxt>
+        </routers>
         <layout>
             <updates>
                 <loewenstark_seo>
@@ -204,6 +213,33 @@
                 <meta_title_length>55</meta_title_length>
                 <product_canonical_tag>1</product_canonical_tag>
                 <disabled_phrases>0</disabled_phrases>
+                <robotstxt><![CDATA[User-Agent: *
+Sitemap: {{store direct_url="sitemap.xml"}}
+User-agent: *
+Disallow: /index.php/
+Disallow: /*?
+Disallow: /*.js$
+Disallow: /*.css$
+Disallow: /*.php$
+Disallow: /admin/
+Disallow: /app/
+Disallow: /catalog/
+Disallow: /catalogsearch/
+Disallow: /checkout/
+Disallow: /customer/
+Disallow: /downloader/
+Disallow: /js/
+Disallow: /lib/
+Disallow: /media/
+Disallow: /newsletter/
+Disallow: /pkginfo/
+Disallow: /report/
+Disallow: /review/
+Disallow: /skin/
+Disallow: /var/
+Disallow: /wishlist/
+Allow: /media/catalog/
+Allow: /media/wysiwyg/]]></robotstxt>
             </seo>
         </catalog>
         <customer>

--- a/app/code/community/Loewenstark/Seo/etc/config.xml
+++ b/app/code/community/Loewenstark/Seo/etc/config.xml
@@ -18,13 +18,13 @@
     </modules>
     <frontend>
         <routers>
-            <Loewenstark_Seo_RobotsTxt>
+            <loewenstark_seo>
                 <use>standard</use>
                 <args>
                     <module>Loewenstark_Seo</module>
                     <frontName>robots.txt</frontName>
                 </args>
-            </Loewenstark_Seo_RobotsTxt>
+            </loewenstark_seo>
         </routers>
         <layout>
             <updates>

--- a/app/code/community/Loewenstark/Seo/etc/system.xml
+++ b/app/code/community/Loewenstark/Seo/etc/system.xml
@@ -85,7 +85,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </disabled_phrases>
-                        <category_meta_description_phrases translate="label comments" module="loewenstark_seo">
+                        <category_meta_description_phrases translate="label comment" module="loewenstark_seo">
                             <label>Category Meta Description Phrases</label>
                             <comment>These phrases are used as/appended to the category meta description. One phrase per line.</comment>
                             <frontend_type>textarea</frontend_type>
@@ -94,7 +94,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </category_meta_description_phrases>
-                        <product_meta_description_phrases translate="label comments" module="loewenstark_seo">
+                        <product_meta_description_phrases translate="label comment" module="loewenstark_seo">
                             <label>Product Meta Description Phrases</label>
                             <comment>These phrases are used as/appended to the product meta description. One phrase per line.</comment>
                             <frontend_type>textarea</frontend_type>
@@ -103,6 +103,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </product_meta_description_phrases>
+                        <robotstxt translate="label comments" module="loewenstark_seo">
+                            <label>robots.txt</label>
+                            <comment><![CDATA[This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""}}</strong>) are available.]]></comment>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>220</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </robotstxt>
                     </fields>
                 </seo>
                 <sitemap>

--- a/app/code/community/Loewenstark/Seo/etc/system.xml
+++ b/app/code/community/Loewenstark/Seo/etc/system.xml
@@ -103,9 +103,9 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </product_meta_description_phrases>
-                        <robotstxt translate="label comments" module="loewenstark_seo">
+                        <robotstxt translate="label comment" module="loewenstark_seo">
                             <label>robots.txt</label>
-                            <comment><![CDATA[This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""}}</strong>) are available.]]></comment>
+                            <comment><![CDATA[This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes, e.g. <strong>{{store direct_url=""}}</strong>, are available.]]></comment>
                             <frontend_type>textarea</frontend_type>
                             <sort_order>220</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/locale/de_DE/Loewenstark_Seo.csv
+++ b/app/locale/de_DE/Loewenstark_Seo.csv
@@ -12,4 +12,4 @@
 "Product Meta Description Phrases","Produkt Meta-Description Phrasen"
 "These phrases are used as/appended to the category meta description. One phrase per line.","Diese Phrasen werden an die Meta-Description von Kategorien angehängt. Eine Phrase pro Zeile."
 "These phrases are used as/appended to the product meta description. One phrase per line.","Diese Phrasen werden an die Meta-Description von Produkten angehängt. Eine Phrase pro Zeile."
-"This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""""}}</strong>) are available.","Dieser Inhalt wird angezeigt, wenn http(s)://domain.com/robots.txt aufgerufen wird. Magento Short-Codes (z.B. <strong>{{store direct_url=""""}}</strong>) sind verfügbar."
+"This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes, e.g. <strong>{{store direct_url=""""""}}</strong>, are available.","Dieser Inhalt wird angezeigt, wenn http(s)://domain.com/robots.txt aufgerufen wird. Magento Short-Codes, z.B. <strong>{{store direct_url=""""""}}</strong>, sind verfügbar."

--- a/app/locale/de_DE/Loewenstark_Seo.csv
+++ b/app/locale/de_DE/Loewenstark_Seo.csv
@@ -12,3 +12,4 @@
 "Product Meta Description Phrases","Produkt Meta-Description Phrasen"
 "These phrases are used as/appended to the category meta description. One phrase per line.","Diese Phrasen werden an die Meta-Description von Kategorien angehängt. Eine Phrase pro Zeile."
 "These phrases are used as/appended to the product meta description. One phrase per line.","Diese Phrasen werden an die Meta-Description von Produkten angehängt. Eine Phrase pro Zeile."
+"This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""""}}</strong>) are available.","Dieser Inhalt wird angezeigt, wenn http(s)://domain.com/robots.txt aufgerufen wird. Magento Short-Codes (z.B. <strong>{{store direct_url=""""}}</strong>) sind verfügbar."

--- a/app/locale/en_US/Loewenstark_Seo.csv
+++ b/app/locale/en_US/Loewenstark_Seo.csv
@@ -12,3 +12,4 @@
 "Product Meta Description Phrases","Product Meta Description Phrases"
 "These phrases are used as/appended to the category meta description. One phrase per line.","These phrases are used as/appended to the category meta description. One phrase per line."
 "These phrases are used as/appended to the product meta description. One phrase per line.","These phrases are used as/appended to the product meta description. One phrase per line."
+"This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""""}}</strong>) are available.","This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""""}}</strong>) are available."

--- a/app/locale/en_US/Loewenstark_Seo.csv
+++ b/app/locale/en_US/Loewenstark_Seo.csv
@@ -12,4 +12,4 @@
 "Product Meta Description Phrases","Product Meta Description Phrases"
 "These phrases are used as/appended to the category meta description. One phrase per line.","These phrases are used as/appended to the category meta description. One phrase per line."
 "These phrases are used as/appended to the product meta description. One phrase per line.","These phrases are used as/appended to the product meta description. One phrase per line."
-"This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""""}}</strong>) are available.","This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes (e.g. <strong>{{store direct_url=""""}}</strong>) are available."
+"This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes, e.g. <strong>{{store direct_url=""""""}}</strong>, are available.","This content is rendered when http://domain.com/robots.txt is accessed. Magento short-codes, e.g. <strong>{{store direct_url=""""""}}</strong>, are available."


### PR DESCRIPTION
With this addition a store owner can change the content of the robots.txt file from within the system configuration. If a robots.txt file already sits in the document root "physically" the webserver configuration decides what to do with it (should be output in most configurations).

This feature is multistore compatible, but only as long the store code is not added to the URL. This case needs special attention.