### PR TITLE
Added robots configuration for catalogsearch/result/index page

### DIFF
--- a/app/code/community/Loewenstark/Seo/Helper/Data.php
+++ b/app/code/community/Loewenstark/Seo/Helper/Data.php
@@ -17,6 +17,7 @@ extends Mage_Core_Helper_Abstract
     const XML_PATH_CUSTOMER_ROBOTS     = 'customer/loewenstark_seo/robots';
     const XML_PATH_CONTACTS_ROBOTS     = 'contacts/contacts/robots';
     const XML_PATH_SITEMAP_ROBOTS      = 'catalog/sitemap/robots';
+    const XML_PATH_SEARCH_ROBOTS       = 'catalog/search/robots';
     const XML_PATH_CONTACTS_BREADCRUMB = 'contacts/contacts/breadcrumb';
     const XML_PATH_CHECKOUT_ROBOTS     = 'checkout/cart/robots';
     const XML_PATH_CATALOG_PHRASES_ENABLED = 'catalog/seo/phrases_enabled';
@@ -70,6 +71,15 @@ extends Mage_Core_Helper_Abstract
     public function getSitemapRobots()
     {
         return Mage::getStoreConfig(self::XML_PATH_SITEMAP_ROBOTS);
+    }
+
+    /**
+     * Robots in catalog/seo_sitemap
+     * @return string
+     */
+    public function getSearchRobots()
+    {
+        return Mage::getStoreConfig(self::XML_PATH_SEARCH_ROBOTS);
     }
 
     /**

--- a/app/code/community/Loewenstark/Seo/Model/Observer.php
+++ b/app/code/community/Loewenstark/Seo/Model/Observer.php
@@ -39,7 +39,7 @@ class Loewenstark_Seo_Model_Observer
             'disabled'  => $isElementDisabled,
         ));
     }
-    
+
     /**
      * event: admin_system_config_section_save_after
      * in: Mage_Adminhtml_System_ConfigController::saveAction()
@@ -52,18 +52,18 @@ class Loewenstark_Seo_Model_Observer
         $_helper = Mage::helper('loewenstark_seo/categoryAttributes');
         $setup = Mage::getModel('catalog/resource_setup', 'core/resource');
         $setup->startSetup();
-        
+
         //get attributes from config and validate
         $config = $_helper->getSeoTextAttributeCodes();
-        
+
         //delete old attributes
         $_helper->deleteAttributesFromCategory( $setup, $config );
-        
+
         //create not existing attributes
         $_helper->addAttributesToCategory( $setup, $config );
 
         $setup->endSetup();
-        
+
     }
 
     /**
@@ -219,6 +219,18 @@ class Loewenstark_Seo_Model_Observer
     public function addRobotsTagToCheckoutCart(Varien_Event_Observer $event)
     {
         $this->_setRobotsHeader($this->_helper()->getCheckoutRobots());
+    }
+
+    /**
+     * event: controller_action_layout_render_before_ . $this->getFullActionName();
+     * in: Mage_Core_Controller_Varien_Action::renderLayout()
+     *
+     * @param $event Varien_Event_Observer
+     * @return void
+     */
+    public function addRobotsTagToCatalogsearch(Varien_Event_Observer $event)
+    {
+        $this->_setRobotsHeader($this->_helper()->getSearchRobots());
     }
 
     /**

--- a/app/code/community/Loewenstark/Seo/etc/config.xml
+++ b/app/code/community/Loewenstark/Seo/etc/config.xml
@@ -109,6 +109,14 @@
                     </loewenstark_seo_contacts_index_index>
                 </observers>
             </controller_action_layout_render_before_catalog_seo_sitemap_category>
+            <controller_action_layout_render_before_catalogsearch_result_index>
+                <observers>
+                    <loewenstark_seo_contacts_index_index>
+                        <class>loewenstark_seo/observer</class>
+                        <method>addRobotsTagToCatalogsearch</method>
+                    </loewenstark_seo_contacts_index_index>
+                </observers>
+            </controller_action_layout_render_before_catalogsearch_result_index>
             <controller_action_layout_render_before_catalog_product_view>
                 <observers>
                     <loewenstark_seo_contacts_index_index>
@@ -222,6 +230,9 @@
             <sitemap>
                 <robots>NOINDEX,FOLLOW</robots>
             </sitemap>
+            <search>
+                <robots>NOINDEX,FOLLOW</robots>
+            </search>
             <seo>
                 <category_canonical_tag>1</category_canonical_tag>
                 <meta_title_length>55</meta_title_length>

--- a/app/code/community/Loewenstark/Seo/etc/system.xml
+++ b/app/code/community/Loewenstark/Seo/etc/system.xml
@@ -147,6 +147,19 @@
                         </category_seo_text_attributes>
                     </fields>
                 </seo>
+                <search>
+                    <fields>
+                        <robots translate="label" module="loewenstark_seo">
+                            <label>Robots Tag</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>loewenstark_seo/system_config_source_cms_robots</source_model>
+                            <sort_order>99</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </robots>
+                    </fields>
+                </search>
                 <sitemap>
                     <fields>
                         <robots translate="label" module="loewenstark_seo">


### PR DESCRIPTION
Now you can change the value of the robots meta tag from the backend under System > Configuration > Catalog > Catalogsearch > Robots Tag.

![catalogsearch_robots_tag](https://cloud.githubusercontent.com/assets/568497/12918493/c1682fb0-cf3f-11e5-83f1-adac0d1acf23.png)
